### PR TITLE
 Add ability to provide custom button texts to ConfirmModal

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Prop name       | Type                | Description
 ----------------|---------------------|-------------
 visible         | boolean (required)  | Whether or not the modal is currently visible
 onOK            | function (required) | A function that will be called when the user clicks "OK"
-OKText          | string (optional)   | The text that is displayed on the OK button
+okText          | string (optional)   | The text that is displayed on the OK button
 onCancel        | function (required) | A function that will be called when the user clicks "Cancel"
 cancelText      | string (optional)   | The text that is displayed on the Cancel button
 disableButtons  | boolean (optional)  | If true, the OK and Cancel buttons will be disabled

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ Prop name       | Type                | Description
 ----------------|---------------------|-------------
 visible         | boolean (required)  | Whether or not the modal is currently visible
 onOK            | function (required) | A function that will be called when the user clicks "OK"
+OKText          | string (optional)   | The text that is displayed on the OK button
 onCancel        | function (required) | A function that will be called when the user clicks "Cancel"
+cancelText      | string (optional)   | The text that is displayed on the Cancel button
 disableButtons  | boolean (optional)  | If true, the OK and Cancel buttons will be disabled
 
 Any other props besides these will be passed to the `Modal` component this renders (so you can use any of the props from `Modal` here as well).

--- a/src/ConfirmModal.jsx
+++ b/src/ConfirmModal.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Modal from './index';
 
-const ConfirmModal = ({ visible, onOK, onCancel, children, disableButtons = false, OKText = 'OK', cancelText = 'Cancel', ...other }) => (
+const ConfirmModal = ({ visible, onOK, onCancel, children, disableButtons = false, okText = 'OK', cancelText = 'Cancel', ...other }) => (
   <Modal visible={visible} {...other}>
     <div className="modal-header">
       <h5 className="modal-title">Confirmation</h5>
@@ -15,7 +15,7 @@ const ConfirmModal = ({ visible, onOK, onCancel, children, disableButtons = fals
         {cancelText}
       </button>
       <button type="button" className="btn btn-primary" onClick={onOK} disabled={disableButtons}>
-        {OKText}
+        {okText}
       </button>
     </div>
   </Modal>
@@ -27,13 +27,13 @@ ConfirmModal.propTypes = {
   onOK: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
   disableButtons: PropTypes.bool,
-  OKText: PropTypes.string,
+  okText: PropTypes.string,
   cancelText: PropTypes.string,
 };
 
 ConfirmModal.defaultProps = {
   disableButtons: false,
-  OKText: 'OK',
+  okText: 'OK',
   cancelText: 'Cancel',
 };
 

--- a/src/ConfirmModal.jsx
+++ b/src/ConfirmModal.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Modal from './index';
 
-const ConfirmModal = ({ visible, onOK, onCancel, children, disableButtons = false, ...other }) => (
+const ConfirmModal = ({ visible, onOK, onCancel, children, disableButtons = false, OKText = 'OK', cancelText = 'Cancel', ...other }) => (
   <Modal visible={visible} {...other}>
     <div className="modal-header">
       <h5 className="modal-title">Confirmation</h5>
@@ -12,10 +12,10 @@ const ConfirmModal = ({ visible, onOK, onCancel, children, disableButtons = fals
     </div>
     <div className="modal-footer">
       <button type="button" className="btn btn-secondary" onClick={onCancel} disabled={disableButtons}>
-        Cancel
+        {cancelText}
       </button>
       <button type="button" className="btn btn-primary" onClick={onOK} disabled={disableButtons}>
-        OK
+        {OKText}
       </button>
     </div>
   </Modal>
@@ -27,10 +27,14 @@ ConfirmModal.propTypes = {
   onOK: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
   disableButtons: PropTypes.bool,
+  OKText: PropTypes.string,
+  cancelText: PropTypes.string,
 };
 
 ConfirmModal.defaultProps = {
   disableButtons: false,
+  OKText: 'OK',
+  cancelText: 'Cancel',
 };
 
 export default ConfirmModal;


### PR DESCRIPTION
In case the user wants to do I18N or similar things, it is necessary to be able to use cusom text in the modal.