### PR TITLE
Include index.d.ts in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "files": [
     "dist",
     "lib",
-    "src"
+    "index.d.ts"
   ],
   "scripts": {
     "test": "npm run lint",


### PR DESCRIPTION
The index.d.ts does not seem to be included in the package. This PR adds the `index.d.ts` and removes `src`, as it is not needed.