### PR TITLE
Use React's events instead of native ones in types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 export type ModalProps = {
     children: React.ReactChild | React.ReactChild[];
-    onClickBackdrop?: ((ev: MouseEvent) => void) | null;
+    onClickBackdrop?: ((ev: React.MouseEvent<HTMLDivElement>) => void) | null;
     visible: boolean;
     wrapperProps?: object | null;
     className?: string;
@@ -19,8 +19,8 @@ export default class Modal extends React.Component<ModalProps, ModalState> {
 }
 
 export type ConfirmModalProps = ModalProps & {
-    onOK: (ev: MouseEvent) => void;
-    onCancel: (ev: MouseEvent) => void;
+    onOK: (ev: React.MouseEvent<HTMLButtonElement>) => void;
+    onCancel: (ev: React.MouseEvent<HTMLButtonElement>) => void;
     /** Defaults to false */
     disableButtons?: boolean;
     /** Defaults to 'OK' */


### PR DESCRIPTION
The native `MouseEvent` is not the same as `React.MouseEvent<T>`. I missed that when I first made these definitions.