### PR TITLE
Set "modal visible" DOM manipulation on didMount

### DIFF
--- a/src/Modal.jsx
+++ b/src/Modal.jsx
@@ -48,7 +48,7 @@ class Modal extends React.Component {
     };
   }
 
-  componentWillMount = () => {
+  componentDidMount = () => {
     if (this.props.visible) {
       modalWillShow();
     }


### PR DESCRIPTION
componentWillMount is deprecated and will be removed soon.

https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html

I tested this locally and works just fine using `componentDidMount` :-)
Thanks for this package.